### PR TITLE
Implementa CRUD para carro na API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,14 +87,23 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
+					<source>21</source>
+					<target>21</target>
 					<annotationProcessorPaths>
 						<path>
 							<groupId>org.mapstruct</groupId>
 							<artifactId>mapstruct-processor</artifactId>
+							<version>1.6.3</version>
 						</path>
 						<path>
 							<groupId>org.projectlombok</groupId>
 							<artifactId>lombok</artifactId>
+							<version>${lombok.version}</version>
+						</path>
+						<path>
+							<groupId>org.projectlombok</groupId>
+							<artifactId>lombok-mapstruct-binding</artifactId>
+							<version>0.2.0</version>
 						</path>
 					</annotationProcessorPaths>
 				</configuration>

--- a/src/main/java/com/example/authentication_api/controller/CarController.java
+++ b/src/main/java/com/example/authentication_api/controller/CarController.java
@@ -1,0 +1,43 @@
+package com.example.authentication_api.controller;
+
+import com.example.authentication_api.model.dto.CarPostDTO;
+import com.example.authentication_api.model.dto.CarPutDTO;
+import com.example.authentication_api.model.entity.Car;
+import com.example.authentication_api.service.CarService;
+import jakarta.validation.Valid;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/car")
+public class CarController {
+    @Autowired
+    private CarService carService;
+
+    @GetMapping
+    public ResponseEntity<List<Car>> findAll() {
+        return ResponseEntity.ok(carService.findAll());
+    }
+
+    @PostMapping
+    public ResponseEntity<Car> save(@RequestBody @Valid CarPostDTO dto) {
+        return new ResponseEntity<>(carService.save(dto), HttpStatus.CREATED);
+    }
+
+    @PutMapping
+    public ResponseEntity<Void> update(@RequestBody @Valid CarPutDTO dto) {
+        carService.update(dto);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable int id) {
+        carService.delete(id);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+}

--- a/src/main/java/com/example/authentication_api/controller/CarController.java
+++ b/src/main/java/com/example/authentication_api/controller/CarController.java
@@ -23,6 +23,16 @@ public class CarController {
         return ResponseEntity.ok(carService.findAll());
     }
 
+    @GetMapping("/find")
+    public ResponseEntity<List<Car>> findByName(@RequestParam String name) {
+        return ResponseEntity.ok(carService.findByName(name));
+    }
+
+    @GetMapping("{id}")
+    public ResponseEntity<Car> findById(@PathVariable int id) {
+        return ResponseEntity.ok(carService.findById(id));
+    }
+
     @PostMapping
     public ResponseEntity<Car> save(@RequestBody @Valid CarPostDTO dto) {
         return new ResponseEntity<>(carService.save(dto), HttpStatus.CREATED);

--- a/src/main/java/com/example/authentication_api/exception/BadRequestException.java
+++ b/src/main/java/com/example/authentication_api/exception/BadRequestException.java
@@ -1,0 +1,7 @@
+package com.example.authentication_api.exception;
+
+public class BadRequestException extends RuntimeException {
+    public BadRequestException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/example/authentication_api/exception/ExceptionResponse.java
+++ b/src/main/java/com/example/authentication_api/exception/ExceptionResponse.java
@@ -1,0 +1,15 @@
+package com.example.authentication_api.exception;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class ExceptionResponse {
+    private int status;
+    private String title;
+    private String message;
+    private LocalDateTime timestamp;
+}

--- a/src/main/java/com/example/authentication_api/exception/RestExceptionHandler.java
+++ b/src/main/java/com/example/authentication_api/exception/RestExceptionHandler.java
@@ -1,0 +1,26 @@
+package com.example.authentication_api.exception;
+
+import lombok.extern.log4j.Log4j2;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+import java.time.LocalDateTime;
+
+@Log4j2
+@ControllerAdvice
+public class RestExceptionHandler {
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<ExceptionResponse> handlerBadRequestException(BadRequestException e) {
+        ExceptionResponse exceptionResponse = (ExceptionResponse.builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .title("Bad Request")
+                .message(e.getMessage())
+                .timestamp(LocalDateTime.now())
+                .build());
+
+        log.warn("BadRequestException foi lancada");
+        return new ResponseEntity<>(exceptionResponse, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/example/authentication_api/model/dto/CarPostDTO.java
+++ b/src/main/java/com/example/authentication_api/model/dto/CarPostDTO.java
@@ -1,0 +1,9 @@
+package com.example.authentication_api.model.dto;
+
+import jakarta.validation.constraints.*;
+
+
+public record CarPostDTO(@NotBlank @NotNull @NotEmpty String name,
+                         @Positive double price,
+                         @Min(1900) int year) {
+}

--- a/src/main/java/com/example/authentication_api/model/dto/CarPutDTO.java
+++ b/src/main/java/com/example/authentication_api/model/dto/CarPutDTO.java
@@ -1,0 +1,11 @@
+package com.example.authentication_api.model.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Positive;
+
+public record CarPutDTO(int id,
+                        @NotBlank String name,
+                        @Positive double price,
+                        @Min(1900) int year) {
+}

--- a/src/main/java/com/example/authentication_api/model/entity/Car.java
+++ b/src/main/java/com/example/authentication_api/model/entity/Car.java
@@ -1,0 +1,19 @@
+package com.example.authentication_api.model.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Entity
+public class Car {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Integer id;
+    private String name;
+    @Column(name = "car_year")
+    private int year;
+    private Double price;
+}

--- a/src/main/java/com/example/authentication_api/model/mapper/CarMapper.java
+++ b/src/main/java/com/example/authentication_api/model/mapper/CarMapper.java
@@ -1,0 +1,15 @@
+package com.example.authentication_api.model.mapper;
+
+import com.example.authentication_api.model.dto.CarPostDTO;
+import com.example.authentication_api.model.dto.CarPutDTO;
+import com.example.authentication_api.model.entity.Car;
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+
+@Mapper
+public abstract class CarMapper {
+    public static CarMapper INSTANCE = Mappers.getMapper(CarMapper.class);
+
+    public abstract Car toCar(CarPostDTO dto);
+    public abstract Car toCar(CarPutDTO dto);
+}

--- a/src/main/java/com/example/authentication_api/repository/CarRepository.java
+++ b/src/main/java/com/example/authentication_api/repository/CarRepository.java
@@ -1,0 +1,7 @@
+package com.example.authentication_api.repository;
+
+import com.example.authentication_api.model.entity.Car;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CarRepository extends JpaRepository<Car, Integer> {
+}

--- a/src/main/java/com/example/authentication_api/repository/CarRepository.java
+++ b/src/main/java/com/example/authentication_api/repository/CarRepository.java
@@ -3,5 +3,8 @@ package com.example.authentication_api.repository;
 import com.example.authentication_api.model.entity.Car;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface CarRepository extends JpaRepository<Car, Integer> {
+    List<Car> findByName(String name);
 }

--- a/src/main/java/com/example/authentication_api/service/CarService.java
+++ b/src/main/java/com/example/authentication_api/service/CarService.java
@@ -1,5 +1,6 @@
 package com.example.authentication_api.service;
 
+import com.example.authentication_api.exception.BadRequestException;
 import com.example.authentication_api.model.dto.CarPostDTO;
 import com.example.authentication_api.model.dto.CarPutDTO;
 import com.example.authentication_api.model.entity.Car;
@@ -22,7 +23,7 @@ public class CarService {
     }
 
     public Car findById(int id) {
-        return carRepository.findById(id).orElseThrow(() -> new RuntimeException("Carro nao encontrado"));
+        return carRepository.findById(id).orElseThrow(() -> new BadRequestException("Carro nao encontrado"));
     }
 
     public List<Car> findByName(String name) {

--- a/src/main/java/com/example/authentication_api/service/CarService.java
+++ b/src/main/java/com/example/authentication_api/service/CarService.java
@@ -1,0 +1,40 @@
+package com.example.authentication_api.service;
+
+import com.example.authentication_api.model.dto.CarPostDTO;
+import com.example.authentication_api.model.dto.CarPutDTO;
+import com.example.authentication_api.model.entity.Car;
+import com.example.authentication_api.model.mapper.CarMapper;
+import com.example.authentication_api.repository.CarRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class CarService {
+    @Autowired
+    private CarRepository carRepository;
+
+    public List<Car> findAll() {
+        return carRepository.findAll();
+    }
+
+    public Car findById(int id) {
+        return carRepository.findById(id).orElseThrow(() -> new RuntimeException("Carro nao encontrado"));
+    }
+
+    public Car save(CarPostDTO dto) {
+        Car car = CarMapper.INSTANCE.toCar(dto);
+        return carRepository.save(car);
+    }
+
+    public void update(CarPutDTO dto) {
+        findById(dto.id());
+        Car car = CarMapper.INSTANCE.toCar(dto);
+        carRepository.save(car);
+    }
+
+    public void delete(int id) {
+        carRepository.delete(findById(id));
+    }
+}

--- a/src/main/java/com/example/authentication_api/service/CarService.java
+++ b/src/main/java/com/example/authentication_api/service/CarService.java
@@ -5,11 +5,13 @@ import com.example.authentication_api.model.dto.CarPutDTO;
 import com.example.authentication_api.model.entity.Car;
 import com.example.authentication_api.model.mapper.CarMapper;
 import com.example.authentication_api.repository.CarRepository;
+import lombok.extern.log4j.Log4j2;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
+@Log4j2
 @Service
 public class CarService {
     @Autowired
@@ -23,8 +25,13 @@ public class CarService {
         return carRepository.findById(id).orElseThrow(() -> new RuntimeException("Carro nao encontrado"));
     }
 
+    public List<Car> findByName(String name) {
+        return carRepository.findByName(name);
+    }
+
     public Car save(CarPostDTO dto) {
         Car car = CarMapper.INSTANCE.toCar(dto);
+        log.info("Salvando carro no db");
         return carRepository.save(car);
     }
 
@@ -32,9 +39,11 @@ public class CarService {
         findById(dto.id());
         Car car = CarMapper.INSTANCE.toCar(dto);
         carRepository.save(car);
+        log.info("Carro id {} atualizado no db", dto.id());
     }
 
     public void delete(int id) {
         carRepository.delete(findById(id));
+        log.info("Carro id {} removido do db", id);
     }
 }

--- a/src/test/java/com/example/authentication_api/controller/CarControllerTest.java
+++ b/src/test/java/com/example/authentication_api/controller/CarControllerTest.java
@@ -1,0 +1,67 @@
+package com.example.authentication_api.controller;
+
+
+import com.example.authentication_api.model.entity.Car;
+import com.example.authentication_api.service.CarService;
+import com.example.authentication_api.util.CarCreator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+
+@ExtendWith(SpringExtension.class)
+class CarControllerTest {
+    @InjectMocks
+    private CarController carController;
+    @Mock
+    private CarService carService;
+
+    @BeforeEach
+    void setUp() {
+        BDDMockito.when(carService.findAll()).thenReturn(List.of(CarCreator.createValidCar()));
+        BDDMockito.when(carService.save(ArgumentMatchers.any())).thenReturn(CarCreator.createValidCar());
+        BDDMockito.doNothing().when(carService).update(CarCreator.createValidCarPutDTO());
+        BDDMockito.doNothing().when(carService).delete(ArgumentMatchers.anyInt());
+    }
+
+    @Test
+    void findAll_Return200_WhenSuccessful() {
+        ResponseEntity<List<Car>> response = carController.findAll();
+
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+        Assertions.assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void save_Return201_WhenSuccessful() {
+        ResponseEntity<Car> response = carController.save(CarCreator.createValidCarPostDTO());
+
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(201));
+        Assertions.assertThat(response.getBody()).isEqualTo(CarCreator.createValidCar());
+    }
+
+    @Test
+    void update_Return204_WhenSuccessful() {
+        ResponseEntity<Void> response = carController.update(CarCreator.createValidCarPutDTO());
+
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(204));
+    }
+
+    @Test
+    void delete_Return204_WhenSuccessful() {
+        ResponseEntity<Void> response = carController.delete(1);
+
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(204));
+    }
+
+
+}

--- a/src/test/java/com/example/authentication_api/controller/CarControllerTest.java
+++ b/src/test/java/com/example/authentication_api/controller/CarControllerTest.java
@@ -28,6 +28,8 @@ class CarControllerTest {
     @BeforeEach
     void setUp() {
         BDDMockito.when(carService.findAll()).thenReturn(List.of(CarCreator.createValidCar()));
+        BDDMockito.when(carService.findByName(ArgumentMatchers.anyString())).thenReturn(List.of(CarCreator.createValidCar()));
+        BDDMockito.when(carService.findById(ArgumentMatchers.anyInt())).thenReturn(CarCreator.createValidCar());
         BDDMockito.when(carService.save(ArgumentMatchers.any())).thenReturn(CarCreator.createValidCar());
         BDDMockito.doNothing().when(carService).update(CarCreator.createValidCarPutDTO());
         BDDMockito.doNothing().when(carService).delete(ArgumentMatchers.anyInt());
@@ -39,6 +41,22 @@ class CarControllerTest {
 
         Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
         Assertions.assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void findByName_Return200_WhenSuccessful() {
+        ResponseEntity<List<Car>> response = carController.findByName("test");
+
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+        Assertions.assertThat(response.getBody()).isNotEmpty();
+    }
+
+    @Test
+    void findById_Return200_WhenSuccessful() {
+        ResponseEntity<Car> response = carController.findById(1);
+
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatusCode.valueOf(200));
+        Assertions.assertThat(response.getBody()).isNotNull();
     }
 
     @Test

--- a/src/test/java/com/example/authentication_api/repository/CarRepositoryTest.java
+++ b/src/test/java/com/example/authentication_api/repository/CarRepositoryTest.java
@@ -50,6 +50,23 @@ class CarRepositoryTest {
     }
 
     @Test
+    void findByName_ReturnsEmptyList_WhenCarIsNotFound() {
+        List<Car> carsByName = carRepository.findByName("");
+
+        Assertions.assertThat(carsByName).isEmpty();
+    }
+
+    @Test
+    void findByName_ReturnsListOfCars_WhenSuccessful() {
+        Car saved = carRepository.save(CarCreator.createCarToBeSaved());
+
+        List<Car> carsByName = carRepository.findByName(saved.getName());
+
+        Assertions.assertThat(carsByName).isNotEmpty();
+        Assertions.assertThat(carsByName).contains(saved);
+    }
+
+    @Test
     void findAll_ReturnsEmptyList_WhenCarIsNotFound() {
         List<Car> all = carRepository.findAll();
 

--- a/src/test/java/com/example/authentication_api/repository/CarRepositoryTest.java
+++ b/src/test/java/com/example/authentication_api/repository/CarRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.example.authentication_api.repository;
+
+import com.example.authentication_api.model.entity.Car;
+import com.example.authentication_api.util.CarCreator;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import java.util.List;
+
+
+@DataJpaTest
+class CarRepositoryTest {
+    @Autowired
+    CarRepository carRepository;
+
+    @Test
+    void save_PersistCar_WhenSuccessful() {
+        Car carToBeSaved = CarCreator.createCarToBeSaved();
+        Car savedCar = carRepository.save(carToBeSaved);
+
+        Assertions.assertThat(savedCar).isNotNull();
+        Assertions.assertThat(savedCar).isEqualTo(carToBeSaved);
+    }
+
+    @Test
+    void save_UpdatesCar_WhenCarAlreadyExists() {
+        Car carToBeSaved = CarCreator.createCarToBeSaved();
+        Car savedCar = carRepository.save(carToBeSaved);
+
+        savedCar.setName("nome atualizado");
+        Car updatedCar = carRepository.save(savedCar);
+
+        Assertions.assertThat(updatedCar).isNotNull();
+        Assertions.assertThat(updatedCar.getId()).isEqualTo(savedCar.getId());
+        Assertions.assertThat(updatedCar.getName()).isEqualTo("nome atualizado");
+    }
+
+    @Test
+    void findAll_ReturnsAllCars_WhenSuccessful() {
+        Car saved = carRepository.save(CarCreator.createCarToBeSaved());
+        carRepository.save(CarCreator.createCarToBeSaved());
+
+        List<Car> all = carRepository.findAll();
+
+        Assertions.assertThat(all).isNotNull().isNotEmpty();
+        Assertions.assertThat(all.size()).isEqualTo(2);
+        Assertions.assertThat(all).contains(saved);
+    }
+
+    @Test
+    void findAll_ReturnsEmptyList_WhenCarIsNotFound() {
+        List<Car> all = carRepository.findAll();
+
+        Assertions.assertThat(all).isEmpty();
+    }
+
+    @Test
+    void delete_RemovesCar_WhenSuccessful() {
+        Car savedCar = carRepository.save(CarCreator.createCarToBeSaved());
+        carRepository.delete(savedCar);
+
+        Assertions.assertThat(carRepository.findAll()).isEmpty();
+    }
+}

--- a/src/test/java/com/example/authentication_api/service/CarServiceTest.java
+++ b/src/test/java/com/example/authentication_api/service/CarServiceTest.java
@@ -1,5 +1,6 @@
 package com.example.authentication_api.service;
 
+import com.example.authentication_api.exception.BadRequestException;
 import com.example.authentication_api.model.entity.Car;
 import com.example.authentication_api.repository.CarRepository;
 import com.example.authentication_api.util.CarCreator;
@@ -37,10 +38,10 @@ class CarServiceTest {
     }
 
     @Test
-    void findById_ThrowsRuntimeException_WhenCarIsNotFound() {
+    void findById_ThrowsBadRequestException_WhenCarIsNotFound() {
         BDDMockito.when(carRepository.findById(ArgumentMatchers.anyInt())).thenReturn(Optional.empty());
 
-        Assertions.assertThatThrownBy(() -> carService.findById(1)).isInstanceOf(RuntimeException.class);
+        Assertions.assertThatThrownBy(() -> carService.findById(1)).isInstanceOf(BadRequestException.class);
     }
 
     @Test

--- a/src/test/java/com/example/authentication_api/service/CarServiceTest.java
+++ b/src/test/java/com/example/authentication_api/service/CarServiceTest.java
@@ -1,7 +1,10 @@
 package com.example.authentication_api.service;
 
+import com.example.authentication_api.model.entity.Car;
 import com.example.authentication_api.repository.CarRepository;
+import com.example.authentication_api.util.CarCreator;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentMatchers;
@@ -19,10 +22,44 @@ class CarServiceTest {
     @Mock
     private CarRepository carRepository;
 
+    @BeforeEach
+    void setUp() {
+        BDDMockito.when(carRepository.findById(ArgumentMatchers.anyInt())).thenReturn(Optional.of(CarCreator.createValidCar()));
+        BDDMockito.when(carRepository.save(ArgumentMatchers.any())).thenReturn(CarCreator.createValidCar());
+        BDDMockito.doNothing().when(carRepository).deleteById(ArgumentMatchers.anyInt());
+    }
+
+    @Test
+    void findById_ReturnsCar_WhenSuccessful() {
+        Car car = carService.findById(1);
+
+        Assertions.assertThat(car).isNotNull();
+    }
+
     @Test
     void findById_ThrowsRuntimeException_WhenCarIsNotFound() {
         BDDMockito.when(carRepository.findById(ArgumentMatchers.anyInt())).thenReturn(Optional.empty());
 
         Assertions.assertThatThrownBy(() -> carService.findById(1)).isInstanceOf(RuntimeException.class);
+    }
+
+    @Test
+    void save_ReturnCar_WhenSuccessful() {
+        Car saved = carService.save(CarCreator.createValidCarPostDTO());
+
+        Assertions.assertThat(saved).isNotNull();
+        Assertions.assertThat(saved.getName()).isEqualTo(CarCreator.createValidCar().getName());
+    }
+
+    @Test
+    void update_UpdatesCar_WhenSuccessful() {
+        Assertions.assertThatCode(() -> carService.update(CarCreator.createValidCarPutDTO()))
+                .doesNotThrowAnyException();
+    }
+
+    @Test
+    void delete_RemovesCar_WhenSuccessful() {
+        Assertions.assertThatCode(() -> carService.delete(1))
+                .doesNotThrowAnyException();
     }
 }

--- a/src/test/java/com/example/authentication_api/service/CarServiceTest.java
+++ b/src/test/java/com/example/authentication_api/service/CarServiceTest.java
@@ -1,0 +1,28 @@
+package com.example.authentication_api.service;
+
+import com.example.authentication_api.repository.CarRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentMatchers;
+import org.mockito.BDDMockito;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.Optional;
+
+@ExtendWith(SpringExtension.class)
+class CarServiceTest {
+    @InjectMocks
+    private CarService carService;
+    @Mock
+    private CarRepository carRepository;
+
+    @Test
+    void findById_ThrowsRuntimeException_WhenCarIsNotFound() {
+        BDDMockito.when(carRepository.findById(ArgumentMatchers.anyInt())).thenReturn(Optional.empty());
+
+        Assertions.assertThatThrownBy(() -> carService.findById(1)).isInstanceOf(RuntimeException.class);
+    }
+}

--- a/src/test/java/com/example/authentication_api/util/CarCreator.java
+++ b/src/test/java/com/example/authentication_api/util/CarCreator.java
@@ -1,0 +1,30 @@
+package com.example.authentication_api.util;
+
+import com.example.authentication_api.model.dto.CarPostDTO;
+import com.example.authentication_api.model.dto.CarPutDTO;
+import com.example.authentication_api.model.entity.Car;
+
+public class CarCreator {
+    public static Car createCarToBeSaved() {
+        return Car.builder()
+                .name("Honda Civic")
+                .price(100_000.00)
+                .year(2017).build();
+    }
+
+    public static Car createValidCar() {
+        return Car.builder()
+                .id(1)
+                .name("Honda Civic")
+                .price(100_000.00)
+                .year(2017).build();
+    }
+
+    public static CarPostDTO createValidCarPostDTO() {
+        return new CarPostDTO("Honda Civic", 100_000.00, 2017);
+    }
+
+    public static CarPutDTO createValidCarPutDTO() {
+        return new CarPutDTO(1, "Honda Civic", 100_000.00, 2017);
+    }
+}


### PR DESCRIPTION
### Objetivo
Este PR implementa o CRUD completo para a entidade `Car` na API, com validação de campos utilizando Spring Validation.

- Endpoints
  - `POST /car`: Cadastra um novo Carro.
  - `GET /car`: Retorna todos Carros cadastrados.
  - `GET /car/{id}`: Retorna o Carro com id especificado.
  - `GET /car/find?`: Retorna os Carros com o nome passado como parâmetro.
  - `PUT /car`: Atualiza os dados de um Carro
  - `DELETE /car/{id}`: Remove um Carro

### Testes
Foram realizados testes via Postman e também testes unitários para `CarRepository`, `CarService` e `CarController`. 